### PR TITLE
split out forwarder and server into separate classes to isolate issue

### DIFF
--- a/manifests/forwarder.pp
+++ b/manifests/forwarder.pp
@@ -118,8 +118,8 @@ class splunk::forwarder (
   # there is non-generic configuration that needs to be declared in addition
   # to the agnostic resources declared here.
   case $::kernel {
-    'Linux': { class { 'splunk::platform::posix': splunkd_port => $splunkd_port,
-                                                  splunk_user  => $splunk_user } }
+    'Linux': { class { 'splunk::platform::posix::forwarder': splunkd_port => $splunkd_port,
+                                                             splunk_user  => $splunk_user } }
     'SunOS': { include splunk::platform::solaris }
     default: { } # no special configuration needed
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,8 +173,8 @@ class splunk (
   # there is non-generic configuration that needs to be declared in addition
   # to the agnostic resources declared here.
   case $::kernel {
-    'Linux': { include splunk::platform::posix   }
-    'SunOS': { include splunk::platform::solaris }
+    'Linux': { include splunk::platform::posix::server   }
+    'SunOS': { include splunk::platform::solaris         }
     default: { } # no special configuration needed
   }
 

--- a/manifests/platform/posix.pp
+++ b/manifests/platform/posix.pp
@@ -20,43 +20,6 @@ class splunk::platform::posix (
 ) inherits splunk::virtual {
 
   include ::splunk::params
-  # Many of the resources declared here are virtual. They will be realized by
-  # the appropriate including class if required.
-
-  # Commands to run to enable the SplunkUniversalForwarder
-  @exec { 'license_splunkforwarder':
-    path    => "${splunk::params::forwarder_dir}/bin",
-    command => 'splunk start --accept-license --answer-yes',
-    user    => $splunk_user,
-    creates => '/opt/splunkforwarder/etc/auth/server.pem',
-    timeout => 0,
-    tag     => 'splunk_forwarder',
-  }
-  @exec { 'enable_splunkforwarder':
-
-    # The path parameter can't be set because the boot-start silently fails on systemd service providers
-    command => "${splunk::params::forwarder_dir}/bin/splunk enable boot-start -user ${splunk_user}",
-    creates => '/etc/init.d/splunk',
-    require => Exec['license_splunkforwarder'],
-    tag     => 'splunk_forwarder',
-  }
-
-  # Commands to run to enable full Splunk
-  @exec { 'license_splunk':
-    path    => "${splunk::params::server_dir}/bin",
-    command => 'splunk start --accept-license --answer-yes',
-    user    => $splunk_user,
-    creates => '/opt/splunk/etc/auth/splunk.secret',
-    timeout => 0,
-    tag     => 'splunk_server',
-  }
-  @exec { 'enable_splunk':
-    # The path parameter can't be set because the boot-start silently fails on systemd service providers
-    command => "${splunk::params::server_dir}/bin/splunk enable boot-start -user ${splunk_user}",
-    creates => '/etc/init.d/splunk',
-    require => Exec['license_splunk'],
-    tag     => 'splunk_server',
-  }
 
   # Modify virtual service definitions specific to the Linux platform. These
   # are virtual resources declared in the splunk::virtual class, which we

--- a/manifests/platform/posix/forwarder.pp
+++ b/manifests/platform/posix/forwarder.pp
@@ -1,0 +1,48 @@
+# Class: splunk::platform::posix::forwarder
+#
+# This class declares virtual resources and collects existing virtual
+# resources for adjustment appropriate to deployment on a Posix host.
+# It extends functionality of either splunk, splunk::forwarder, or
+# both.
+#
+# Parameters: none
+#
+# Actions:
+#
+#   Declares, tags, and modifies virtual resources realized by other classes
+#   in the splunk module.
+#
+# Requires: nothing
+#
+class splunk::platform::posix::forwarder (
+  $splunkd_port = $splunk::splunkd_port,
+  $splunk_user = $splunk::params::splunk_user,
+) inherits splunk::virtual {
+
+  include ::splunk::params
+  class {'::splunk::platform::posix':
+    splunkd_port => $splunkd_port,
+    splunk_user  => $splunk_user,
+  }
+  # Many of the resources declared here are virtual. They will be realized by
+  # the appropriate including class if required.
+
+  # Commands to run to enable the SplunkUniversalForwarder
+  @exec { 'license_splunkforwarder':
+    path    => "${splunk::params::forwarder_dir}/bin",
+    command => 'splunk start --accept-license --answer-yes',
+    user    => $splunk_user,
+    creates => '/opt/splunkforwarder/etc/auth/server.pem',
+    timeout => 0,
+    tag     => 'splunk_forwarder',
+  }
+  @exec { 'enable_splunkforwarder':
+
+    # The path parameter can't be set because the boot-start silently fails on systemd service providers
+    command => "${splunk::params::forwarder_dir}/bin/splunk enable boot-start -user ${splunk_user}",
+    creates => '/etc/init.d/splunk',
+    require => Exec['license_splunkforwarder'],
+    tag     => 'splunk_forwarder',
+  }
+
+}

--- a/manifests/platform/posix/server.pp
+++ b/manifests/platform/posix/server.pp
@@ -1,0 +1,42 @@
+# Class: splunk::platform::posix::server
+#
+# This class declares virtual resources and collects existing virtual
+# resources for adjustment appropriate to deployment on a Posix host.
+# It extends functionality of either splunk, splunk::forwarder, or
+# both.
+#
+# Parameters: none
+#
+# Actions:
+#
+#   Declares, tags, and modifies virtual resources realized by other classes
+#   in the splunk module.
+#
+# Requires: nothing
+#
+class splunk::platform::posix::server {
+
+  include ::splunk::params
+  include ::splunk::platform::posix
+
+  # Many of the resources declared here are virtual. They will be realized by
+  # the appropriate including class if required.
+
+  # Commands to run to enable full Splunk
+  @exec { 'license_splunk':
+    path    => "${splunk::params::server_dir}/bin",
+    command => 'splunk start --accept-license --answer-yes',
+    user    => $splunk_user,
+    creates => '/opt/splunk/etc/auth/splunk.secret',
+    timeout => 0,
+    tag     => 'splunk_server',
+  }
+  @exec { 'enable_splunk':
+    # The path parameter can't be set because the boot-start silently fails on systemd service providers
+    command => "${splunk::params::server_dir}/bin/splunk enable boot-start -user ${splunk_user}",
+    creates => '/etc/init.d/splunk',
+    require => Exec['license_splunk'],
+    tag     => 'splunk_server',
+  }
+
+}


### PR DESCRIPTION
where the server class execs are being executed inappropriately, causing
an error.
